### PR TITLE
Make all Assert methods static

### DIFF
--- a/src/Framework/Assert.hhi
+++ b/src/Framework/Assert.hhi
@@ -2,47 +2,47 @@
 
 abstract class PHPUnit_Framework_Assert {
   // Assertions
-  public function assertArrayHasKey(
+  public static function assertArrayHasKey(
     arraykey $key,
     array $array,
     string $message = '',
   ): void;
-  public function assertArrayNotHasKey(
+  public static function assertArrayNotHasKey(
     arraykey $key,
     array $array,
     string $message = '',
   ): void;
-  public function assertArraySubset(
+  public static function assertArraySubset(
     array $subset,
     array $array,
     bool $strict = false,
     string $message = '',
   ): void;
-  public function assertAttributeContains(
+  public static function assertAttributeContains(
     mixed $needle,
     string $name,
     mixed $object,
     string $message = '',
   ): void;
-  public function assertAttributeContainsOnly(
+  public static function assertAttributeContainsOnly(
     string $type,
     string $name,
     mixed $object,
     ?bool $isNativeType = null,
     string $message = '',
   ): void;
-  public function assertAttributeCount(
+  public static function assertAttributeCount(
     int $expected,
     string $name,
     mixed $object,
     string $message = '',
   ): void;
-  public function assertAttributeEmpty(
+  public static function assertAttributeEmpty(
     string $name,
     mixed $object,
     string $message = '',
   ): void;
-  public function assertAttributeEquals(
+  public static function assertAttributeEquals(
     mixed $expect,
     string $name,
     mixed $object,
@@ -52,67 +52,67 @@ abstract class PHPUnit_Framework_Assert {
     bool $canonicalize = false,
     bool $ignoreCase = false,
   ): void;
-  public function assertAttributeGreaterThan(
+  public static function assertAttributeGreaterThan(
     mixed $expected,
     string $name,
     mixed $object,
     string $message = '',
   ): void;
-  public function assertAttributeGreaterThanOrEqual(
+  public static function assertAttributeGreaterThanOrEqual(
     mixed $expected,
     string $name,
     mixed $object,
     string $message = '',
   ): void;
-  public function assertAttributeInstanceOf<T>(
+  public static function assertAttributeInstanceOf<T>(
     classname<T> $expected,
     string $name,
     mixed $object,
     string $msg = '',
   ): void;
-  public function assertAttributeInternalType(
+  public static function assertAttributeInternalType(
     string $expected,
     string $name,
     mixed $object,
     string $message = '',
   ): void;
-  public function assertAttributeLessThan(
+  public static function assertAttributeLessThan(
     mixed $expected,
     string $name,
     mixed $object,
     string $message = '',
   ): void;
-  public function assertAttributeLessThanOrEqual(
+  public static function assertAttributeLessThanOrEqual(
     mixed $expected,
     string $name,
     mixed $object,
     string $message = '',
   ): void;
-  public function assertAttributeNotContains(
+  public static function assertAttributeNotContains(
     mixed $needle,
     string $name,
     mixed $object,
     string $message = '',
   ): void;
-  public function assertAttributeNotContainsOnly(
+  public static function assertAttributeNotContainsOnly(
     string $type,
     string $name,
     mixed $object,
     ?bool $isNativeType = null,
     string $message = '',
   ): void;
-  public function assertAttributeNotCount(
+  public static function assertAttributeNotCount(
     int $expected,
     string $name,
     mixed $object,
     string $message = '',
   ): void;
-  public function assertAttributeNotEmpty(
+  public static function assertAttributeNotEmpty(
     string $name,
     mixed $object,
     string $message = '',
   ): void;
-  public function assertAttributeNotEquals(
+  public static function assertAttributeNotEquals(
     mixed $expect,
     string $name,
     mixed $object,
@@ -122,103 +122,103 @@ abstract class PHPUnit_Framework_Assert {
     bool $canonicalize = false,
     bool $ignoreCase = false,
   ): void;
-  public function assertAttributeNotInstanceOf<T>(
+  public static function assertAttributeNotInstanceOf<T>(
     classname<T> $expected,
     string $name,
     mixed $object,
     string $msg = '',
   ): void;
-  public function assertAttributeNotInternalType(
+  public static function assertAttributeNotInternalType(
     string $expected,
     string $name,
     mixed $object,
     string $message = '',
   ): void;
-  public function assertAttributeNotSame(
+  public static function assertAttributeNotSame(
     mixed $expect,
     string $name,
     mixed $object,
     string $msg = '',
   ): void;
-  public function assertAttributeSame(
+  public static function assertAttributeSame(
     mixed $expect,
     string $name,
     mixed $object,
     string $msg = '',
   ): void;
-  public function assertClassHasAttribute(
+  public static function assertClassHasAttribute(
     string $name,
     string $class,
     string $message = '',
   ): void;
-  public function assertClassHasStaticAttribute(
+  public static function assertClassHasStaticAttribute(
     string $name,
     string $class,
     string $message = '',
   ): void;
-  public function assertClassNotHasAttribute(
+  public static function assertClassNotHasAttribute(
     string $name,
     string $class,
     string $message = '',
   ): void;
-  public function assertClassNotHasStaticAttribute(
+  public static function assertClassNotHasStaticAttribute(
     string $name,
     string $class,
     string $message = '',
   ): void;
-  public function assertContains(
+  public static function assertContains(
     mixed $needle,
     mixed $array,
     string $msg = '',
   ): void;
-  public function assertContainsOnly(
+  public static function assertContainsOnly(
     string $type,
     mixed $array,
     ?bool $isNativeType = null,
     string $message = '',
   ): void;
-  public function assertContainsOnlyInstancesOf<T>(
+  public static function assertContainsOnlyInstancesOf<T>(
     classname<T> $class,
     mixed $array,
     string $message = '',
   ): void;
-  public function assertCount(
+  public static function assertCount(
     int $expected,
     mixed $haystack,
     string $message = '',
   ): void;
-  public function assertDirectoryExists(
+  public static function assertDirectoryExists(
     string $directory,
     string $message = '',
   ): void;
-  public function assertDirectoryIsReadable(
+  public static function assertDirectoryIsReadable(
     string $directory,
     string $message = '',
   ): void;
-  public function assertDirectoryIsWritable(
+  public static function assertDirectoryIsWritable(
     string $directory,
     string $message = '',
   ): void;
-  public function assertDirectoryNotExists(
+  public static function assertDirectoryNotExists(
     string $directory,
     string $message = '',
   ): void;
-  public function assertDirectoryNotIsReadable(
+  public static function assertDirectoryNotIsReadable(
     string $directory,
     string $message = '',
   ): void;
-  public function assertDirectoryNotIsWritable(
+  public static function assertDirectoryNotIsWritable(
     string $directory,
     string $message = '',
   ): void;
-  public function assertEmpty(mixed $actual, string $message = ''): void;
-  public function assertEqualXMLStructure(
+  public static function assertEmpty(mixed $actual, string $message = ''): void;
+  public static function assertEqualXMLStructure(
     /*DOMElement*/ $expected,
     /*DOMElement*/ $actual,
     bool $check = false,
     string $message = '',
   ): void;
-  public function assertEquals(
+  public static function assertEquals(
     mixed $expect,
     mixed $actual,
     string $msg = '',
@@ -227,131 +227,131 @@ abstract class PHPUnit_Framework_Assert {
     bool $canonicalize = false,
     bool $ignoreCase = false,
   ): void;
-  public function assertFalse(mixed $condition, string $message = ''): void;
-  public function assertFileEquals(
+  public static function assertFalse(mixed $condition, string $message = ''): void;
+  public static function assertFileEquals(
     string $expected,
     string $actual,
     string $message = '',
   ): void;
-  public function assertFileExists(
+  public static function assertFileExists(
     string $filename,
     string $message = '',
   ): void;
-  public function assertFileIsReadable(
+  public static function assertFileIsReadable(
     string $file,
     string $message = '',
   ): void;
-  public function assertFileIsWritable(
+  public static function assertFileIsWritable(
     string $file,
     string $message = '',
   ): void;
-  public function assertFileNotEquals(
+  public static function assertFileNotEquals(
     string $expected,
     string $actual,
     string $message = '',
   ): void;
-  public function assertFileNotExists(
+  public static function assertFileNotExists(
     string $filename,
     string $message = '',
   ): void;
-  public function assertFileNotIsReadable(
+  public static function assertFileNotIsReadable(
     string $file,
     string $message = '',
   ): void;
-  public function assertFileNotIsWritable(
+  public static function assertFileNotIsWritable(
     string $file,
     string $message = '',
   ): void;
-  public function assertFinite(mixed $action, string $message = ''): void;
-  public function assertGreaterThan(
+  public static function assertFinite(mixed $action, string $message = ''): void;
+  public static function assertGreaterThan(
     mixed $expected,
     mixed $actual,
     string $message = '',
   ): void;
-  public function assertGreaterThanOrEqual(
+  public static function assertGreaterThanOrEqual(
     mixed $expected,
     mixed $actual,
     string $message = '',
   ): void;
-  public function assertInfinite(mixed $action, string $message = ''): void;
-  public function assertInstanceOf<T>(
+  public static function assertInfinite(mixed $action, string $message = ''): void;
+  public static function assertInstanceOf<T>(
     classname<T> $expected,
     mixed $actual,
     string $msg = '',
   ): void;
-  public function assertInternalType(
+  public static function assertInternalType(
     string $expected,
     mixed $actual,
     string $message = '',
   ): void;
-  public function assertIsReadable(
+  public static function assertIsReadable(
     string $filename,
     string $message = '',
   ): void;
-  public function assertIsWritable(
+  public static function assertIsWritable(
     string $filename,
     string $message = '',
   ): void;
-  public function assertJson(string $actual, string $message = ''): void;
-  public function assertJsonFileEqualsJsonFile(
+  public static function assertJson(string $actual, string $message = ''): void;
+  public static function assertJsonFileEqualsJsonFile(
     string $expected,
     string $actual,
     string $message = '',
   ): void;
-  public function assertJsonFileNotEqualsJsonFile(
+  public static function assertJsonFileNotEqualsJsonFile(
     string $expected,
     string $actual,
     string $message = '',
   ): void;
-  public function assertJsonStringEqualsJsonFile(
+  public static function assertJsonStringEqualsJsonFile(
     string $expected,
     string $actual,
     string $message = '',
   ): void;
-  public function assertJsonStringEqualsJsonString(
+  public static function assertJsonStringEqualsJsonString(
     string $exepcted,
     string $actual,
     string $message = '',
   ): void;
-  public function assertJsonStringNotEqualsJsonFile(
+  public static function assertJsonStringNotEqualsJsonFile(
     string $expected,
     string $actual,
     string $message = '',
   ): void;
-  public function assertJsonStringNotEqualsJsonString(
+  public static function assertJsonStringNotEqualsJsonString(
     string $exepcted,
     string $actual,
     string $message = '',
   ): void;
-  public function assertLessThan(
+  public static function assertLessThan(
     mixed $expected,
     mixed $actual,
     string $message = '',
   ): void;
-  public function assertLessThanOrEqual(
+  public static function assertLessThanOrEqual(
     mixed $expected,
     mixed $actual,
     string $message = '',
   ): void;
-  public function assertNan(mixed $action, string $message = ''): void;
-  public function assertNotContains(
+  public static function assertNan(mixed $action, string $message = ''): void;
+  public static function assertNotContains(
     mixed $needle,
     mixed $array,
     string $msg = '',
   ): void;
-  public function assertNotContainsOnly(
+  public static function assertNotContainsOnly(
     string $type,
     mixed $array,
     ?bool $isNativeType = null,
     string $message = '',
   ): void;
-  public function assertNotCount(
+  public static function assertNotCount(
     int $expected,
     mixed $haystack,
     string $message = '',
   ): void;
-  public function assertNotEmpty(mixed $actual, string $message = ''): void;
-  public function assertNotEquals(
+  public static function assertNotEmpty(mixed $actual, string $message = ''): void;
+  public static function assertNotEquals(
     mixed $expect,
     mixed $actual,
     string $msg = '',
@@ -360,176 +360,176 @@ abstract class PHPUnit_Framework_Assert {
     bool $canonicalize = false,
     bool $ignoreCase = false,
   ): void;
-  public function assertNotFalse(
+  public static function assertNotFalse(
     mixed $condition,
     string $message = '',
   ): void;
-  public function assertNotInstanceOf<T>(
+  public static function assertNotInstanceOf<T>(
     classname<T> $expected,
     mixed $actual,
     string $msg = '',
   ): void;
-  public function assertNotInternalType(
+  public static function assertNotInternalType(
     string $expected,
     mixed $actual,
     string $message = '',
   ): void;
-  public function assertNotIsReadable(
+  public static function assertNotIsReadable(
     string $filename,
     string $message = '',
   ): void;
-  public function assertNotIsWritable(
+  public static function assertNotIsWritable(
     string $filename,
     string $message = '',
   ): void;
-  public function assertNotNull(mixed $actual, string $msg = ''): void;
-  public function assertNotRegExp(
+  public static function assertNotNull(mixed $actual, string $msg = ''): void;
+  public static function assertNotRegExp(
     string $pattern,
     string $string,
     string $message = '',
   ): void;
-  public function assertNotSame(
+  public static function assertNotSame(
     mixed $expect,
     mixed $actual,
     string $msg = '',
   ): void;
-  public function assertNotSameSize(
+  public static function assertNotSameSize(
     array $expected,
     array $actual,
     string $message = '',
   ): void;
-  public function assertNotTrue(
+  public static function assertNotTrue(
     mixed $conditions,
     string $message = '',
   ): void;
-  public function assertNull(mixed $actual, string $msg = ''): void;
-  public function assertObjectHasAttribute(
+  public static function assertNull(mixed $actual, string $msg = ''): void;
+  public static function assertObjectHasAttribute(
     string $name,
     mixed $object,
     string $message = '',
   ): void;
-  public function assertObjectNotHasAttribute(
+  public static function assertObjectNotHasAttribute(
     string $name,
     mixed $object,
     string $message = '',
   ): void;
-  public function assertRegExp(
+  public static function assertRegExp(
     string $pattern,
     string $string,
     string $message = '',
   ): void;
-  public function assertSame(
+  public static function assertSame(
     mixed $expect,
     mixed $actual,
     string $msg = '',
   ): void;
-  public function assertSameSize(
+  public static function assertSameSize(
     array $expected,
     array $actual,
     string $message = '',
   ): void;
-  public function assertStringEndsNotWith(
+  public static function assertStringEndsNotWith(
     string $suffix,
     string $string,
     string $message = '',
   ): void;
-  public function assertStringEndsWith(
+  public static function assertStringEndsWith(
     string $suffix,
     string $string,
     string $message = '',
   ): void;
-  public function assertStringEqualsFile(
+  public static function assertStringEqualsFile(
     string $expected,
     string $catual,
     string $message = '',
   ): void;
-  public function assertStringMatchesFormat(
+  public static function assertStringMatchesFormat(
     string $format,
     string $string,
     string $message = '',
   ): void;
-  public function assertStringMatchesFormatFile(
+  public static function assertStringMatchesFormatFile(
     string $format,
     string $string,
     string $message = '',
   ): void;
-  public function assertStringNotEqualsFile(
+  public static function assertStringNotEqualsFile(
     string $expected,
     string $catual,
     string $message = '',
   ): void;
-  public function assertStringNotMatchesFormat(
+  public static function assertStringNotMatchesFormat(
     string $format,
     string $string,
     string $message = '',
   ): void;
-  public function assertStringNotMatchesFormatFile(
+  public static function assertStringNotMatchesFormatFile(
     string $format,
     string $string,
     string $message = '',
   ): void;
-  public function assertStringStartsNotWith(
+  public static function assertStringStartsNotWith(
     string $prefix,
     string $string,
     string $message = '',
   ): void;
-  public function assertStringStartsWith(
+  public static function assertStringStartsWith(
     string $prefix,
     string $string,
     string $message = '',
   ): void;
-  public function assertThat<T>(
+  public static function assertThat<T>(
     mixed $value,
     PHPUnit_Framework_Constraint<T> $constraint,
     string $message = '',
   ): void;
-  public function assertTrue(mixed $conditions, string $message = ''): void;
-  public function assertXmlFileEqualsXmlFile(
+  public static function assertTrue(mixed $conditions, string $message = ''): void;
+  public static function assertXmlFileEqualsXmlFile(
     string $expected,
     string $actual,
     string $message = '',
   ): void;
-  public function assertXmlFileNotEqualsXmlFile(
+  public static function assertXmlFileNotEqualsXmlFile(
     string $expected,
     string $actual,
     string $message = '',
   ): void;
-  public function assertXmlStringEqualsXmlFile(
+  public static function assertXmlStringEqualsXmlFile(
     string $expected,
     string $actual,
     string $message = '',
   ): void;
-  public function assertXmlStringEqualsXmlString(
+  public static function assertXmlStringEqualsXmlString(
     string $expected,
     string $actual,
     string $message = '',
   ): void;
-  public function assertXmlStringNotEqualsXmlFile(
+  public static function assertXmlStringNotEqualsXmlFile(
     string $expected,
     string $actual,
     string $message = '',
   ): void;
-  public function assertXmlStringNotEqualsXmlString(
+  public static function assertXmlStringNotEqualsXmlString(
     string $expected,
     string $actual,
     string $message = '',
   ): void;
 
   // Test control
-  public function fail(string $msg = ''): noreturn;
-  public function markTestIncomplete(string $message = ''): noreturn;
-  public function markTestSkipped(string $message = ''): noreturn;
+  public static function fail(string $msg = ''): noreturn;
+  public static function markTestIncomplete(string $message = ''): noreturn;
+  public static function markTestSkipped(string $message = ''): noreturn;
 
   // Constraints
-  public function anything(): PHPUnit_Framework_Constraint_IsAnything;
-  public function arrayHasKey(
+  public static function anything(): PHPUnit_Framework_Constraint_IsAnything;
+  public static function arrayHasKey(
     arraykey $key,
   ): PHPUnit_Framework_Constraint_ArrayHasKey;
-  public function attribute<T>(
+  public static function attribute<T>(
     PHPUnit_Framework_Constraint<T> $constraint,
     string $attributeName,
   ): PHPUnit_Framework_Constraint_Attribute<T>;
-  public function attributeEqualTo<T>(
+  public static function attributeEqualTo<T>(
     string $attributeName,
     mixed $value,
     float $delta = 0.0,
@@ -537,95 +537,95 @@ abstract class PHPUnit_Framework_Assert {
     bool $canonicalize = false,
     bool $ignoreCase = false,
   ): PHPUnit_Framework_Constraint_Attribute<T>;
-  public function callback<T>(
+  public static function callback<T>(
     (function(T): bool) $callback,
   ): PHPUnit_Framework_Constraint_Callback<T>;
-  public function classHasAttribute<T>(
+  public static function classHasAttribute<T>(
     string $attributeName,
   ): PHPUnit_Framework_Constraint_ClassHasAttribute<T>;
-  public function classHasStaticAttribute<T>(
+  public static function classHasStaticAttribute<T>(
     string $attributeName,
   ): PHPUnit_Framework_Constraint_ClassHasStaticAttribute<T>;
-  public function contains<T>(
+  public static function contains<T>(
     mixed $value,
     bool $checkForObjectIdentity = true,
     bool $checkForNonObjectIdentity = false,
   ): PHPUnit_Framework_Constraint_TraversableContains<T>;
-  public function containsOnly<T>(
+  public static function containsOnly<T>(
     string $type,
   ): PHPUnit_Framework_Constraint_TraversableContainsOnly<T>;
-  public function containsOnlyInstancesOf<T>(
+  public static function containsOnlyInstancesOf<T>(
     classname<T> $className,
   ): PHPUnit_Framework_Constraint_TraversableContainsOnly<classname<T>>;
-  public function countOf<T>(
+  public static function countOf<T>(
     int $count,
   ): PHPUnit_Framework_Constraint_Count<T>;
-  public function directoryExists(
+  public static function directoryExists(
   ): PHPUnit_Framework_Constraint_DirectoryExists;
-  public function equalTo(
+  public static function equalTo(
     mixed $value,
     float $delta = 0.0,
     int $maxDepth = 10,
     bool $canonicalize = false,
     bool $ignoreCase = false,
   ): PHPUnit_Framework_Constraint_IsEqual;
-  public function fileExists(): PHPUnit_Framework_Constraint_FileExists;
-  public function greaterThan(
+  public static function fileExists(): PHPUnit_Framework_Constraint_FileExists;
+  public static function greaterThan(
     $value,
   ): PHPUnit_Framework_Constraint_GreaterThan;
-  public function greaterThanOrEqual(
+  public static function greaterThanOrEqual(
     $value,
   ): PHPUnit_Framework_Constraint_Or<num>;
-  public function identicalTo(
+  public static function identicalTo(
     $value,
   ): PHPUnit_Framework_Constraint_IsIdentical;
-  public function isEmpty(): PHPUnit_Framework_Constraint_IsEmpty;
-  public function isFalse(): PHPUnit_Framework_Constraint_IsFalse;
-  public function isFinite(): PHPUnit_Framework_Constraint_IsFinite;
-  public function isInfinite(): PHPUnit_Framework_Constraint_IsInfinite;
-  public function isInstanceOf<T>(
+  public static function isEmpty(): PHPUnit_Framework_Constraint_IsEmpty;
+  public static function isFalse(): PHPUnit_Framework_Constraint_IsFalse;
+  public static function isFinite(): PHPUnit_Framework_Constraint_IsFinite;
+  public static function isInfinite(): PHPUnit_Framework_Constraint_IsInfinite;
+  public static function isInstanceOf<T>(
     classname<T> $className,
   ): PHPUnit_Framework_Constraint_IsInstanceOf<T>;
-  public function isJson(): PHPUnit_Framework_Constraint_IsJson;
-  public function isNan(): PHPUnit_Framework_Constraint_IsNan;
-  public function isNull(): PHPUnit_Framework_Constraint_IsNull;
-  public function isReadable(): PHPUnit_Framework_Constraint_IsReadable;
-  public function isTrue(): PHPUnit_Framework_Constraint_IsTrue;
-  public function isType(string $type): PHPUnit_Framework_Constraint_IsType;
-  public function isWritable(): PHPUnit_Framework_Constraint_IsWritable;
-  public function lessThan($value): PHPUnit_Framework_Constraint_LessThan;
-  public function lessThanOrEqual(
+  public static function isJson(): PHPUnit_Framework_Constraint_IsJson;
+  public static function isNan(): PHPUnit_Framework_Constraint_IsNan;
+  public static function isNull(): PHPUnit_Framework_Constraint_IsNull;
+  public static function isReadable(): PHPUnit_Framework_Constraint_IsReadable;
+  public static function isTrue(): PHPUnit_Framework_Constraint_IsTrue;
+  public static function isType(string $type): PHPUnit_Framework_Constraint_IsType;
+  public static function isWritable(): PHPUnit_Framework_Constraint_IsWritable;
+  public static function lessThan($value): PHPUnit_Framework_Constraint_LessThan;
+  public static function lessThanOrEqual(
     $value,
   ): PHPUnit_Framework_Constraint_Or<num>;
-  public function logicalAnd<T>(
+  public static function logicalAnd<T>(
     PHPUnit_Framework_Constraint<T> ...$constraints
   ): PHPUnit_Framework_Constraint_And<T>;
-  public function logicalNot<T>(
+  public static function logicalNot<T>(
     PHPUnit_Framework_Constraint<T> $constraint,
   ): PHPUnit_Framework_Constraint_Not<T>;
-  public function logicalOr<T>(
+  public static function logicalOr<T>(
     PHPUnit_Framework_Constraint<T> ...$constraints
   ): PHPUnit_Framework_Constraint_Or<T>;
-  public function logicalXor<T>(
+  public static function logicalXor<T>(
     PHPUnit_Framework_Constraint<T> ...$constraints
   ): PHPUnit_Framework_Constraint_Xor<T>;
-  public function matches(
+  public static function matches(
     string $string,
   ): PHPUnit_Framework_Constraint_StringMatches;
-  public function matchesRegularExpression(
+  public static function matchesRegularExpression(
     string $pattern,
   ): PHPUnit_Framework_Constraint_PCREMatch;
-  public function objectHasAttribute<T>(
+  public static function objectHasAttribute<T>(
     string $attributeName,
   ): PHPUnit_Framework_Constraint_ObjectHasAttribute<T>;
-  public function stringContains(
+  public static function stringContains(
     string $string,
     bool $case = true,
   ): PHPUnit_Framework_Constraint_StringContains;
-  public function stringEndsWith(
+  public static function stringEndsWith(
     string $suffix,
   ): PHPUnit_Framework_Constraint_StringEndsWith;
-  public function stringStartsWith(
+  public static function stringStartsWith(
     string $prefix,
   ): PHPUnit_Framework_Constraint_StringStartsWith;
 


### PR DESCRIPTION
This brings the `PHPUnit_Framework_Assert::assert*()` signatures in line with [PHPUnit 5.7.27](https://github.com/sebastianbergmann/phpunit/blob/5.7.27/src/Framework/Assert.php) by declaring them to be static.